### PR TITLE
refactor: remove debugging statements from codebase

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -19,13 +19,12 @@ final class AuthController extends Controller
     /**
      * Generate an API token for the user.
      *
+     *
      * @throws ValidationException
      */
     public function generateToken(ApiLoginRequest $request): JsonResponse
     {
-        ray($request->all());
         $validated = $request->validated();
-        ray($validated);
 
         $user = User::where('email', $validated['email'])->first();
 

--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -49,7 +49,6 @@ final class CategoryController extends Controller
         $category->load(['events' => function ($query): void {
             $query->with('favoritedBy', 'organizer');
         }]);
-        ray($category);
 
         return CategoryResource::make($category);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,8 +61,6 @@ final class User extends Authenticatable
             return false;
         }
 
-        ray($this->email);
-
         return $this->emailDomainIsValid($this->email)
             && $this->hasVerifiedEmail();
         // && $this->is_admin
@@ -102,7 +100,6 @@ final class User extends Authenticatable
     {
         /** @var array<string> $validDomains */
         $validDomains = config('events_api.auth.valid_email_domains');
-        ray($validDomains);
 
         return collect($validDomains)->contains(fn ($domain): bool => str_ends_with($email, $domain));
     }

--- a/tests/Architecture/DebugTest.php
+++ b/tests/Architecture/DebugTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+test('debug functions are not used in the codebase')
+    ->expect(['dd', 'dump', 'ray', 'var_dump', 'print_r'])
+    ->not->toBeUsed()
+    ->ignoring(['tests', 'database/factories', 'database/seeders']);
+
+test('laravel debug helpers are not used in the codebase')
+    ->expect(['debug', 'Log::debug'])
+    ->not->toBeUsed()
+    ->ignoring(['tests', 'database/factories', 'database/seeders']);
+
+test('no debugging packages are used in production')
+    ->expect('App')
+    ->not->toUse([
+        'Barryvdh\Debugbar',
+        'Laravel\Telescope',
+        'Spatie\Ray',
+    ])
+    ->ignoring(['tests', 'database/factories', 'database/seeders', 'App\Providers']);


### PR DESCRIPTION
Eliminate debugging statements from the User model, 
CategoryController, and AuthController to clean up the 
codebase. Introduce tests to ensure that debugging 
functions and packages are not used in production, 
promoting better coding practices and maintaining 
code quality.