### PR TITLE
refactor: simplify feature image attribute in EventResource

### DIFF
--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -16,8 +16,7 @@ final class EventResource extends JsonResource
             'id' => $this->id,
             'attributes' => [
                 'title' => $this->title,
-                'feature_image' => $this->feature_image,
-                'feature_image_url' => $this->feature_image_url,
+                'feature_image' => $this->feature_image_url,
                 'start_date' => $this->start_date,
                 'end_date' => $this->end_date,
                 $this->mergeWhen($request->routeIs('events.show'), [


### PR DESCRIPTION
Updates the EventResource to use 'feature_image_url' directly as the 
value for 'feature_image'. This change streamlines the data structure 
returned by the resource and reduces redundancy in the attribute 
definition.