### PR TITLE
feat(requests): add slug validation and preparation logic

### DIFF
--- a/app/Http/Requests/Organizer/StoreOrganizerRequest.php
+++ b/app/Http/Requests/Organizer/StoreOrganizerRequest.php
@@ -11,7 +11,7 @@ final class StoreOrganizerRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return true;
+        return auth()->check();
     }
 
     /**
@@ -28,6 +28,8 @@ final class StoreOrganizerRequest extends FormRequest
             'website' => ['nullable', 'url'],
             'social_media' => ['nullable', 'url'],
             'logo' => ['nullable', 'string'],
+            'user_id' => ['required', 'exists:users,id'],
+            'slug' => ['nullable', 'string', 'unique:organizers'],
         ];
     }
 
@@ -72,9 +74,15 @@ final class StoreOrganizerRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $userId = auth()->id();
+
+        if ( ! $userId) {
+            throw new \Illuminate\Auth\AuthenticationException('Unauthenticated.');
+        }
+
         $this->merge([
-            'slug' => Str::slug($this->name),
-            'user_id' => $this->user()->id,
+            'user_id' => $userId,
+            'slug' => $this->input('slug') ?? Str::slug($this->input('name')),
         ]);
     }
 }

--- a/app/Http/Requests/Organizer/UpdateOrganizerRequest.php
+++ b/app/Http/Requests/Organizer/UpdateOrganizerRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Organizer;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 final class UpdateOrganizerRequest extends FormRequest
@@ -26,6 +27,11 @@ final class UpdateOrganizerRequest extends FormRequest
                 'email',
                 Rule::unique('organizers')->ignore($this->route('organizer')),
             ],
+            'slug' => [
+                'nullable',
+                'string',
+                Rule::unique('organizers')->ignore($this->route('organizer')),
+            ],
             'phone' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'address' => ['nullable', 'string'],
@@ -33,5 +39,17 @@ final class UpdateOrganizerRequest extends FormRequest
             'social_media' => ['nullable', 'url'],
             'logo' => ['nullable', 'string'],
         ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('name') && ! $this->has('slug')) {
+            $this->merge([
+                'slug' => Str::slug($this->input('name')),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
Add slug field to the validation rules for both storing and updating 
organizers. Implement logic to automatically generate a slug from the 
name if it is not provided. Ensure user authentication is required 
when storing an organizer. This improves data integrity and user 
experience by ensuring unique slugs and proper user association.