### PR TITLE
feat: add status field to EventResource response

### DIFF
--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -28,6 +28,7 @@ final class EventResource extends JsonResource
                     'registration_deadline' => $this->registration_deadline,
                     'registration_status' => $this->registration_status,
                     'event_type' => $this->event_type,
+                    'status' => $this->status,
                     'online_url' => $this->online_url,
                     'created_at' => $this->created_at,
                     'updated_at' => $this->updated_at,


### PR DESCRIPTION
Add the 'status' field to the EventResource to include the current 
status of the event in the API response. This change enhances the 
information provided to clients and improves the usability of the 
event data.