### PR TITLE
feat(events): modify slug field to be nullable and non-unique

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -50,9 +50,8 @@ final class EventResource extends Resource
                                 $set('slug', Str::slug($state));
                             }),
                         TextInput::make('slug')
-                            ->required()
-                            ->maxLength(255)
-                            ->unique(ignoreRecord: true),
+                            ->nullable()
+                            ->maxLength(255),
                         Hidden::make('user_id')
                             ->default(fn () => auth()->id()),
                         Textarea::make('description')

--- a/app/Http/Requests/Event/StoreEventRequest.php
+++ b/app/Http/Requests/Event/StoreEventRequest.php
@@ -23,7 +23,7 @@ final class StoreEventRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:255'],
-            'slug' => ['nullable', 'string', 'max:255', 'unique:events,slug'],
+            'slug' => ['nullable', 'string', 'max:255'],
             'description' => ['required', 'string', 'max:65535'],
             'location' => ['required', 'string', 'max:255'],
             'feature_image' => ['nullable', function ($attribute, $value, $fail): void {

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -155,6 +155,14 @@ final class Event extends Model
             ->exists();
     }
 
+    /**
+     * Get the route key for the model.
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
     protected function featureImageUrl(): Attribute
     {
         return Attribute::make(

--- a/database/migrations/2025_02_27_021433_modify_slug_in_events_table.php
+++ b/database/migrations/2025_02_27_021433_modify_slug_in_events_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            // Drop the unique constraint
+            $table->dropUnique(['slug']);
+
+            // Make the slug field nullable
+            $table->string('slug')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            // Restore the unique constraint
+            $table->unique('slug');
+
+            // Make the slug field required again
+            $table->string('slug')->nullable(false)->change();
+        });
+    }
+};


### PR DESCRIPTION
Update the events table migration to drop the unique constraint on the 
slug field and make it nullable. Adjust the EventResource and 
StoreEventRequest to reflect these changes, allowing for more 
flexibility in event creation. Add a method to get the route key 
by ID for better model routing.