### PR TITLE
fix(requests): simplify online_url validation rules

### DIFF
--- a/app/Http/Requests/Event/StoreEventRequest.php
+++ b/app/Http/Requests/Event/StoreEventRequest.php
@@ -52,7 +52,7 @@ final class StoreEventRequest extends FormRequest
             'registration_status' => ['required', 'string', Rule::enum(RegistrationStatus::class)],
             'event_type' => ['required', 'string', Rule::enum(EventType::class)],
             /** @ignoreParam */
-            'online_url' => ['required_if:event_type,online,hybrid', 'nullable', 'url'],
+            'online_url' => ['nullable', 'url'],
             /** @ignoreParam */
             'status' => ['sometimes', 'string', Rule::enum(EventStatus::class)],
             /** @ignoreParam */

--- a/app/Http/Requests/Event/UpdateEventRequest.php
+++ b/app/Http/Requests/Event/UpdateEventRequest.php
@@ -37,7 +37,7 @@ final class UpdateEventRequest extends FormRequest
             'registration_status' => ['sometimes', 'required', 'string', Rule::enum(RegistrationStatus::class)],
             'event_type' => ['sometimes', 'required', 'string', Rule::enum(EventType::class)],
             /** @ignoreParam */
-            'online_url' => ['sometimes', 'required_if:event_type,online,hybrid', 'nullable', 'url'],
+            'online_url' => ['sometimes', 'nullable', 'url'],
             /** @ignoreParam */
             'status' => ['sometimes', 'string', Rule::enum(EventStatus::class)],
             /** @ignoreParam */


### PR DESCRIPTION
Update the validation rules for the online_url field in both 
UpdateEventRequest and StoreEventRequest. Remove the 
'required_if' condition to allow for more flexible input, 
ensuring that online_url can be nullable while still 
validating as a URL when provided. This change improves 
the usability of the event creation and update processes.