### PR TITLE
refactor: rename ticket_id to ticket_type_id

### DIFF
--- a/app/Http/Resources/EventParticipantResource.php
+++ b/app/Http/Resources/EventParticipantResource.php
@@ -19,7 +19,7 @@ final class EventParticipantResource extends JsonResource
                 'user_id' => $this->user_id,
                 'status' => $this->status->value,
                 'participation_type' => $this->participation_type->value,
-                'ticket_id' => $this->ticket_id,
+                'ticket_type_id' => $this->ticket_type_id,
                 'check_in_time' => $this->check_in_time,
                 'joined_at' => $this->joined_at,
                 'created_at' => $this->created_at,


### PR DESCRIPTION
Update EventParticipantResource to use ticket_type_id instead of 
ticket_id for clarity and consistency in the data structure. This 
change improves the understanding of the data being represented.