### PR TITLE
refactor(database): rename ticket_id to ticket_type_id

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -144,9 +144,20 @@ final class EventController extends Controller
             $event->tags()->sync($tags);
         }
 
+        // Load the event with necessary relationships and counts
+        $event->load(['category', 'tags'])
+            ->loadCount('favorites');
+
+        // Load is_favorited if user is authenticated
+        if (auth()->check()) {
+            $event->loadExists(['favorites as is_favorited' => function ($query): void {
+                $query->where('user_id', auth()->id());
+            }]);
+        }
+
         return response()->json([
             'message' => 'Event updated successfully',
-            'data' => new EventResource($event->load(['category', 'tags'])),
+            'data' => new EventResource($event),
         ]);
     }
 

--- a/app/Http/Requests/Event/UpdateEventRequest.php
+++ b/app/Http/Requests/Event/UpdateEventRequest.php
@@ -22,7 +22,7 @@ final class UpdateEventRequest extends FormRequest
     {
         return [
             'title' => ['sometimes', 'required', 'string', 'max:255'],
-            'slug' => ['sometimes', 'required', 'string', 'max:255', Rule::unique('events')->ignore($this->event)],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255', Rule::unique('events')->ignore($this->event)],
             'description' => ['sometimes', 'required', 'string', 'max:65535'],
             'location' => ['sometimes', 'required', 'string', 'max:255'],
             'feature_image' => ['sometimes', function ($attribute, $value, $fail): void {

--- a/database/migrations/2025_02_09_111910_create_event_participants_table.php
+++ b/database/migrations/2025_02_09_111910_create_event_participants_table.php
@@ -23,7 +23,7 @@ return new class() extends Migration
                 ->onDelete('cascade');
             $table->string('status');
             $table->string('participation_type');
-            $table->foreignUlid('ticket_type_id')
+            $table->foreignId('ticket_type_id')
                 ->nullable()
                 ->constrained('ticket_types')
                 ->onDelete('set null');


### PR DESCRIPTION
Rename the `ticket_id` column to `ticket_type_id` in the 
`event_participants` table and update its type from ULID 
(string) to unsigned big integer. Adjust the foreign key 
constraint to reference the `ticket_types` table instead of 
the `tickets` table. This change improves clarity and 
ensures proper relationships in the database schema.